### PR TITLE
Camera Movement Constraint

### DIFF
--- a/AcademyGameJam/AcademyGameJam/GameScene/GS+DidMove.swift
+++ b/AcademyGameJam/AcademyGameJam/GameScene/GS+DidMove.swift
@@ -26,7 +26,7 @@ extension GameScene {
         setupVirtualController()
         
         //MARK: - ADD MAP
-        setupMap(center: .init(x: view.bounds.midX, y: view.bounds.midY))
+        setupMap(center: center)
         
         // MARK: - ADD FLOWERS
         setupFlowers()

--- a/AcademyGameJam/AcademyGameJam/GameScene/GameScene.swift
+++ b/AcademyGameJam/AcademyGameJam/GameScene/GameScene.swift
@@ -39,8 +39,17 @@ class GameScene: SKScene, SKPhysicsContactDelegate, ObservableObject {
     }
     
     override func didFinishUpdate() {
-        if let player = player {
-            cameraNode?.position = player.position
+        if let player = player,
+           let camera = cameraNode,
+           let scene = scene {
+            
+            if player.position.x - scene.size.width/2 > bounds.minX && player.position.x + scene.size.width/2 < bounds.maxX {
+                camera.position.x = player.position.x
+            }
+            
+            if player.position.y - scene.size.height/2 > bounds.minY && player.position.y + scene.size.height/2 < bounds.maxY {
+                camera.position.y = player.position.y
+            }
         }
     }
 }


### PR DESCRIPTION
# Changes

- Implemented some logic in the `GameScene`'s `didFinishUpdate()` to only move the camera if it isn't going to be "out of bounds".


## Observations

This should be done on the player movement aswell. Currently, it is getting off screen.